### PR TITLE
Allow Omitting Type for Update

### DIFF
--- a/src/Resource.js
+++ b/src/Resource.js
@@ -83,8 +83,9 @@ class Resource {
       .catch(extractErrorResponse);
   }
 
-  update(record) {
+  update(partialRecord) {
     // http://jsonapi.org/faq/#wheres-put
+    const record = Object.assign({}, partialRecord, { type: this.name });
     const requestData = { data: record };
     return this.api
       .patch(`${this.name}/${record.id}`, requestData)

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -244,19 +244,19 @@ describe('Resource', () => {
 
   describe('create', () => {
     it('can create a record', () => {
-      const expectedRequestBody = {
-        data: {
-          type: 'widgets',
-          ...record,
-        },
-      };
+      const partialRecord = { attributes: { key: 'value' } };
 
       const responseBody = { data: record };
       api.post.mockResolvedValue({ data: responseBody });
 
-      const result = resource.create(record);
+      const result = resource.create(partialRecord);
 
-      expect(api.post).toHaveBeenCalledWith('widgets', expectedRequestBody);
+      expect(api.post).toHaveBeenCalledWith('widgets', {
+        data: {
+          ...partialRecord,
+          type: 'widgets',
+        },
+      });
       return expect(result).resolves.toEqual(responseBody);
     });
 

--- a/test/Resource.spec.js
+++ b/test/Resource.spec.js
@@ -274,12 +274,15 @@ describe('Resource', () => {
 
   describe('update', () => {
     it('can update a record', () => {
+      const partialRecord = { id: '1', attributes: { key: 'value' } };
       const responseBody = { data: record };
       api.patch.mockResolvedValue({ data: responseBody });
 
-      const result = resource.update(record);
+      const result = resource.update(partialRecord);
 
-      expect(api.patch).toHaveBeenCalledWith('widgets/1', { data: record });
+      expect(api.patch).toHaveBeenCalledWith('widgets/1', {
+        data: { ...partialRecord, type: 'widgets' },
+      });
       return expect(result).resolves.toEqual(responseBody);
     });
 


### PR DESCRIPTION
The docs say that the `type` argument to `update()` is ignored and can be omitted, but this was not previously correct. This PR corrects the code to match the docs.